### PR TITLE
Updated TimelineJS3 dependency to pull from bower instead of github.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "angular": "~1.4.0",
     "angular-route": "~1.4.0",
-    "TimelineJS3": "https://github.com/NUKnightLab/TimelineJS3.git#3.3.6"
+    "TimelineJS3": "~3.3.9"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.0"


### PR DESCRIPTION
I was having issues with gulp wiredep trying to inject TimelineJS3 files into index.html.
(The js and css files need to be defined in main within bower.json to be able to be injected)
So, I created a TimelineJS3 package for bower and updated your TimelineJS3 dependency to point to bower instead of github.
